### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/softinsaorg/430d8147-98af-4c5f-a832-44299b832998/a39f53a1-6ea7-49e4-9ab7-49c94a6ffa3d/_apis/work/boardbadge/474ffcd7-f35b-423a-85c3-6a647cc12b4f)](https://dev.azure.com/softinsaorg/430d8147-98af-4c5f-a832-44299b832998/_boards/board/t/a39f53a1-6ea7-49e4-9ab7-49c94a6ffa3d/Microsoft.RequirementCategory)
 # azure-boards

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 [![Board Status](https://dev.azure.com/softinsaorg/430d8147-98af-4c5f-a832-44299b832998/a39f53a1-6ea7-49e4-9ab7-49c94a6ffa3d/_apis/work/boardbadge/474ffcd7-f35b-423a-85c3-6a647cc12b4f)](https://dev.azure.com/softinsaorg/430d8147-98af-4c5f-a832-44299b832998/_boards/board/t/a39f53a1-6ea7-49e4-9ab7-49c94a6ffa3d/Microsoft.RequirementCategory)
+
 # azure-boards


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#159](https://dev.azure.com/softinsaorg/430d8147-98af-4c5f-a832-44299b832998/_workitems/edit/159). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.